### PR TITLE
Add support loading base SwinT pretrain weights

### DIFF
--- a/auto3dseg/algorithm_templates/swinunetr/configs/hyper_parameters.yaml
+++ b/auto3dseg/algorithm_templates/swinunetr/configs/hyper_parameters.yaml
@@ -1,6 +1,7 @@
 amp: true
 bundle_root: monai/apps/auto3dseg/algorithms/templates/SwinUNETR
 ckpt_path: $@bundle_root + '/model_fold' + str(@fold)
+pretrained_path: $'pretrained_model' + '/swin_unetr.base_5000ep_f48_lr2e-4_pretrained.pt'
 data_file_base_dir: /home/yuchengt/Downloads/MONAI-dev/monai/apps/auto3dseg/algorithms/templates/datasets/Task09_Spleen
 data_list_file_path: /home/yuchengt/Downloads/MONAI-dev/monai/apps/auto3dseg/algorithms/templates/datasets/datafolds/msd_task09_spleen_folds.json
 determ: false

--- a/auto3dseg/algorithm_templates/swinunetr/docs/README.md
+++ b/auto3dseg/algorithm_templates/swinunetr/docs/README.md
@@ -10,6 +10,8 @@ This model is the auto 3d implementation [1] with Beyond the Cranial Vault (BTCV
 
 The training was performed with at least 16GB-memory GPUs.
 
+It's recommended to use Swin Transformer encoder pretrained weights for training, train code will automatically download base Swin-T encoder.
+
 ## commands example
 
 Execute model training:

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
@@ -33,6 +33,7 @@ from monai.data import DataLoader, partition_dataset
 from monai.inferers import sliding_window_inference
 from monai.metrics import compute_meandice
 from monai.utils import set_determinism
+from monai.apps import download_url
 
 
 def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
@@ -47,6 +47,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
 
     amp = parser.get_parsed_content("amp")
     ckpt_path = parser.get_parsed_content("ckpt_path")
+    pretrained_path = parser.get_parsed_content("pretrained_path")
     data_file_base_dir = parser.get_parsed_content("data_file_base_dir")
     data_list_file_path = parser.get_parsed_content("data_list_file_path")
     determ = parser.get_parsed_content("determ")
@@ -162,6 +163,21 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
     model = parser.get_parsed_content("network")
     model = model.to(device)
 
+    #Load pre-trained weights
+    if not os.path.isfile(pretrained_path):
+        download_url(
+            url="https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/swin_unetr.base_5000ep_f48_lr2e-4_pretrained.pt", 
+            filepath=pretrained_path
+        )
+    store_dict = model.state_dict()
+    model_dict = torch.load(pretrained_path)["state_dict"]
+    for key in model_dict.keys():
+        if 'out' not in key:
+            store_dict[key] = model_dict[key]
+
+    model.load_state_dict(store_dict)
+    print('Use pretrained weights')
+
     if torch.cuda.device_count() > 1:
         model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model)
 
@@ -200,6 +216,8 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
             model.module.load_state_dict(torch.load(finetune["pretrained_ckpt_name"], map_location=device))
         else:
             model.load_state_dict(torch.load(finetune["pretrained_ckpt_name"], map_location=device))
+    elif os.path.isfile(pretrained_path):
+        print("[info] Using pretrained weights of Swin Transformer encoder")
     else:
         print("[info] training from scratch")
 


### PR DESCRIPTION
This adds support loading Base swin transformer encoder pre-trained weights for training, train script will automatically download pretrained weights. 

Evaluation performed, comparison of w, w/o pretrained weights:
**Task 02 Heart MRI: Orange line used pretrained weights:**
![Screenshot from 2022-10-18 13-32-23](https://user-images.githubusercontent.com/58751975/196538179-f4094b6b-c4a0-4a90-b519-04b9a164bae7.png)

**Task09 Spleen CT: Blue line used pretrained weights**
<img width="557" alt="Screen Shot 2022-10-17 at 11 17 59 AM" src="https://user-images.githubusercontent.com/58751975/196538776-d75e8fb4-a03d-4b30-ad44-20a35d7176d5.png">
sed pretrained weights
