### PR TITLE
Add norm name arg to Swin UNETR BTCV

### DIFF
--- a/SwinUNETR/BTCV/main.py
+++ b/SwinUNETR/BTCV/main.py
@@ -59,6 +59,7 @@ parser.add_argument("--world_size", default=1, type=int, help="number of nodes f
 parser.add_argument("--rank", default=0, type=int, help="node rank for distributed training")
 parser.add_argument("--dist-url", default="tcp://127.0.0.1:23456", type=str, help="distributed url")
 parser.add_argument("--dist-backend", default="nccl", type=str, help="distributed backend")
+parser.add_argument("--norm_name", default="instance", type=str, help="normalization name")
 parser.add_argument("--workers", default=8, type=int, help="number of workers")
 parser.add_argument("--feature_size", default=48, type=int, help="feature size")
 parser.add_argument("--in_channels", default=1, type=int, help="number of input channels")


### PR DESCRIPTION
The `--norm_name` argument is not present in the argparse. This will crash the `main.py` script in BTCV if `--distributed` is enabled. 

https://github.com/Project-MONAI/research-contributions/blob/1dde7a112c69785b4fb5cd58d5b73f3fa5bdc577/SwinUNETR/BTCV/main.py#L208-L209

This commit simply adds the `--norm_name` arg in the same location as is done in the BRATS 21 `main.py` file. 
