### PR TITLE
fix cache_rate

### DIFF
--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -395,18 +395,32 @@ class DintsAlgo(BundleAlgo):
 
         output_path = self.fill_records["hyper_parameters.yaml"]["bundle_root"]
         parser = ConfigParser(globals=False)
-        parser.read_config(os.path.join(output_path, "configs", "hyper_parameters_search.yaml"))
+        config_search_fname = os.path.join(output_path, "configs", "hyper_parameters_search.yaml")
+        parser.read_config(config_search_fname)
         allow_search_set = [k for k in parser.get("searching")]
+        allow_search_set_root = [k for k in parser.get()]
 
         parser = ConfigParser(globals=False)
-        parser.read_config(os.path.join(output_path, "configs", "hyper_parameters.yaml"))
+        config_fname = os.path.join(output_path, "configs", "hyper_parameters.yaml")
+        parser.read_config(config_fname)
         allow_train_set = [k for k in parser.get("training")]
+        allow_train_set_root = [k for k in parser.get()]
 
+        allow_search_set_root.append("CUDA_VISIBLE_DEVICES")
+        allow_train_set_root.append("CUDA_VISIBLE_DEVICES")
+
+        # architecture search
         for k, v in params.items():
-            if k not in allow_search_set:
+            if k in allow_search_set_root:
                 dints_search_params.update({k: v})
-            else:
+            elif k in allow_search_set:
                 dints_search_params.update({"searching#" + k: v})
+            else:
+                logger.info(
+                    f"The keys {k} cannot be found in the {config_search_fname} for architecture search. "
+                    f"Skipped overriding key {k} in search."
+                )
+            
         cmd, devices_info = self._create_cmd(dints_search_params)
         cmd_search = cmd.replace("train.py", "search.py")
         self._run_cmd(cmd_search, devices_info)
@@ -414,10 +428,15 @@ class DintsAlgo(BundleAlgo):
         # training
         dints_train_params = {}
         for k, v in params.items():
-            if k not in allow_train_set:
+            if k in allow_train_set_root:
                 dints_train_params.update({k: v})
-            else:
+            elif k in allow_train_set:
                 dints_train_params.update({"training#" + k: v})
+            else:
+                logger.info(
+                    f"The keys {k} cannot be found in the {config_fname} for training. "
+                    f"Skipped overriding key {k} in train."
+                )
         cmd, devices_info = self._create_cmd(dints_train_params)
         return self._run_cmd(cmd, devices_info)
 

--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -394,10 +394,8 @@ class DintsAlgo(BundleAlgo):
         # without the prefix searching# or training#
 
         output_path = self.fill_records["hyper_parameters.yaml"]["bundle_root"]
-
         parser = ConfigParser(globals=False)
         parser.read_config(os.path.join(output_path, "configs", "hyper_parameters_search.yaml"))
-
         allow_search_set = [k for k in parser.get("searching")]
 
         parser = ConfigParser(globals=False)

--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -418,7 +418,7 @@ class DintsAlgo(BundleAlgo):
             else:
                 logger.info(
                     f"The keys {k} cannot be found in the {config_search_fname} for architecture search. "
-                    f"Skipped overriding key {k} in search."
+                    f"Skipped overriding key {k}."
                 )
 
         cmd, devices_info = self._create_cmd(dints_search_params)
@@ -435,7 +435,7 @@ class DintsAlgo(BundleAlgo):
             else:
                 logger.info(
                     f"The keys {k} cannot be found in the {config_fname} for training. "
-                    f"Skipped overriding key {k} in train."
+                    f"Skipped overriding key {k}."
                 )
         cmd, devices_info = self._create_cmd(dints_train_params)
         return self._run_cmd(cmd, devices_info)

--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -420,7 +420,7 @@ class DintsAlgo(BundleAlgo):
                     f"The keys {k} cannot be found in the {config_search_fname} for architecture search. "
                     f"Skipped overriding key {k} in search."
                 )
-            
+
         cmd, devices_info = self._create_cmd(dints_search_params)
         cmd_search = cmd.replace("train.py", "search.py")
         self._run_cmd(cmd_search, devices_info)

--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -392,12 +392,12 @@ class DintsAlgo(BundleAlgo):
         # keys must be allowed without "searching" and "training", such as 'num_epochs'. If a key can be found in
         # searching in hyper_parameter_search.yaml or training in hyper_parameter.yaml, the key can be used directly
         # without the prefix searching# or training#
-        
+
         output_path = self.fill_records["hyper_parameters.yaml"]["bundle_root"]
 
         parser = ConfigParser(globals=False)
         parser.read_config(os.path.join(output_path, "configs", "hyper_parameters_search.yaml"))
-        
+
         allow_search_set = [k for k in parser.get("searching")]
 
         parser = ConfigParser(globals=False)


### PR DESCRIPTION
Fix #172 
Signed-off-by: Mingxin Zheng <18563433+mingxin-zheng@users.noreply.github.com>

Dints in Auto3DSeg has an override function `train` that first search and then train. Previously, all `train_param` override, such as `num_epochs`, will be passed to the search and train functions with additional key prefix: `searching#` and `training#`, because these hyperparameters are under `searching` and `training` in `hyper_parameter_search.yml` and `hyper_parameter.yml`, respectively.

This PR fixes an issue that user cannot pass an override if the parameter is not under `searching` or `training` in those config files. The PR will add the prefix only if the override key can be found under `searching` in `hyper_parameter_search.yml` and `training` in `hyper_parameter.yml`. For example, `cache_rate` is not either under `searching` or `training`. So the function won't add `searching#` or `training#` in the override process and the param can be correctly set in `search` and `train`.

This will also fix if the user wants to override other params in the root level.