### PR TITLE
test lazy resampling

### DIFF
--- a/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
@@ -10,7 +10,7 @@ transforms_train:
     padding_mode: [border, border]
     # device: "cuda"
     dtype: "$torch.float32"
-    verbose: false  # whether to print more pending operations info
+  verbose: false  # whether to print more pending operations info
   transforms:
   - _target_: LoadImaged
     keys: ["@image_key", "@label_key"]

--- a/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
@@ -14,6 +14,7 @@ transforms_train:
   transforms:
   - _target_: LoadImaged
     keys: ["@image_key", "@label_key"]
+    image_only: true
   - _target_: EnsureChannelFirstd
     keys: ["@image_key", "@label_key"]
   - _target_: Orientationd

--- a/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
@@ -8,6 +8,7 @@ transforms_train:
   overrides:
     mode: [bilinear, nearest]
     padding_mode: [border, border]
+    # device: "cuda"
     dtype: "$torch.float32"
   transforms:
   - _target_: LoadImaged
@@ -39,7 +40,7 @@ transforms_train:
     spatial_size: "@training#patch_size"
     mode: [constant, constant]
 
-  - _target_: IdentityD  # make the label uptodate (the next transform requires label_key input
+  - _target_: IdentityD  # make the label uptodate (the next transform requires label_key input)
     keys: ["@label_key"]
 
   # data augmentation
@@ -63,7 +64,7 @@ transforms_train:
     mode: [trilinear, nearest]
     prob: 0.16
 
-  - _target_: IdentityD   # make image up-to-date
+  - _target_: IdentityD   # make image up-to-date, before this line the cropping hasn't been applied
     keys: ["@image_key"]
 
   - _target_: RandGaussianSmoothd

--- a/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
@@ -10,6 +10,7 @@ transforms_train:
     padding_mode: [border, border]
     # device: "cuda"
     dtype: "$torch.float32"
+    verbose: false  # whether to print more pending operations info
   transforms:
   - _target_: LoadImaged
     keys: ["@image_key", "@label_key"]

--- a/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/transforms_train.yaml
@@ -3,6 +3,12 @@ image_key: image
 label_key: label
 transforms_train:
   _target_: Compose
+  lazy_evaluation: true
+  override_keys: ["@image_key", "@label_key"]
+  overrides:
+    mode: [bilinear, nearest]
+    padding_mode: [border, border]
+    dtype: "$torch.float32"
   transforms:
   - _target_: LoadImaged
     keys: ["@image_key", "@label_key"]
@@ -33,6 +39,9 @@ transforms_train:
     spatial_size: "@training#patch_size"
     mode: [constant, constant]
 
+  - _target_: IdentityD  # make the label uptodate (the next transform requires label_key input
+    keys: ["@label_key"]
+
   # data augmentation
   - _target_: RandCropByLabelClassesd
     keys: ["@image_key", "@label_key"]
@@ -53,6 +62,10 @@ transforms_train:
     max_zoom: 1.2
     mode: [trilinear, nearest]
     prob: 0.16
+
+  - _target_: IdentityD   # make image up-to-date
+    keys: ["@image_key"]
+
   - _target_: RandGaussianSmoothd
     keys: "@image_key"
     sigma_x: [0.5, 1.15]


### PR DESCRIPTION
requires the latest dev

by default the resampling is using the pytorch backend, using
`BUILD_MONAI=1` within a monai docker container can trigger monai's precompiled resampling backend