### PR TITLE
Fix nvidia-smi query wrong gpus which fails MONAI integration test

### DIFF
--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -13,6 +13,7 @@ import numpy as np
 import os
 import subprocess
 import sys
+import torch
 import yaml
 
 from copy import deepcopy
@@ -24,13 +25,11 @@ from monai.apps.utils import get_logger
 logger = get_logger(module_name=__name__)
 
 
-def get_gpu_available_memory():
-    command = "nvidia-smi --query-gpu=memory.free --format=csv"
-    memory_free_info = (
-        subprocess.check_output(command.split()).decode("ascii").split("\n")[:-1][1:]
-    )
-    memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
-    return memory_free_values
+def get_mem_from_visible_gpus():
+    available_mem_visible_gpus = []
+    for d in range(torch.cuda.device_count()):
+        available_mem_visible_gpus.append(torch.cuda.mem_get_info(device=d)[0])
+    return available_mem_visible_gpus
 
 
 class DintsAlgo(BundleAlgo):
@@ -259,9 +258,9 @@ class DintsAlgo(BundleAlgo):
             if "range_num_sw_batch_size" in specs:
                 range_num_sw_batch_size = specs["range_num_sw_batch_size"]
 
-        mem = get_gpu_available_memory()
-        device_id = np.argmin(mem) if type(mem) is list else 0
-        print(f"[info] gpu device {device_id} with minimum memory")
+        mem = get_mem_from_visible_gpus()
+        device_id = np.argmin(mem)
+        print(f"[info] gpu device {device_id} with minimum memory in {mem}")
 
         mem = min(mem) if type(mem) is list else mem
         mem = round(float(mem) / 1024.0)
@@ -281,6 +280,7 @@ class DintsAlgo(BundleAlgo):
                 "validation_data_device", ["cpu", "gpu"]
             )
             device_factor = 2.0 if validation_data_device == "gpu" else 1.0
+            ps_environ = os.environ.copy()  # ensure the CUDA_VISIBLE_DEVICES is copied when used.
 
             try:
                 cmd = "python {0:s}dummy_runner.py ".format(
@@ -293,7 +293,7 @@ class DintsAlgo(BundleAlgo):
                 cmd += f"--num_images_per_batch {num_images_per_batch} "
                 cmd += f"--num_sw_batch_size {num_sw_batch_size} "
                 cmd += f"--validation_data_device {validation_data_device}"
-                _ = subprocess.run(cmd.split(), check=True)
+                _ = subprocess.run(cmd.split(), env=ps_environ, check=True)
             except RuntimeError as e:
                 if "out of memory" in str(e):
                     return (

--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -260,7 +260,7 @@ class DintsAlgo(BundleAlgo):
 
         mem = get_mem_from_visible_gpus()
         device_id = np.argmin(mem)
-        print(f"[info] gpu device {device_id} with minimum memory in {mem}")
+        print(f"[info] device {device_id} in visible GPU list has the minimum memory.")
 
         mem = min(mem) if type(mem) is list else mem
         mem = round(float(mem) / 1024.0)

--- a/auto3dseg/algorithm_templates/segresnet2d/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/segresnet2d/scripts/algo.py
@@ -12,6 +12,7 @@
 import numpy as np
 import os
 import subprocess
+import torch
 import yaml
 
 from copy import deepcopy
@@ -19,13 +20,11 @@ from monai.apps.auto3dseg import BundleAlgo
 from monai.bundle import ConfigParser
 
 
-def get_gpu_available_memory():
-    command = "nvidia-smi --query-gpu=memory.free --format=csv"
-    memory_free_info = (
-        subprocess.check_output(command.split()).decode("ascii").split("\n")[:-1][1:]
-    )
-    memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
-    return memory_free_values
+def get_mem_from_visible_gpus():
+    available_mem_visible_gpus = []
+    for d in range(torch.cuda.device_count()):
+        available_mem_visible_gpus.append(torch.cuda.mem_get_info(device=d)[0])
+    return available_mem_visible_gpus
 
 
 class Segresnet2dAlgo(BundleAlgo):
@@ -266,9 +265,9 @@ class Segresnet2dAlgo(BundleAlgo):
             if "range_num_sw_batch_size" in specs:
                 range_num_sw_batch_size = specs["range_num_sw_batch_size"]
 
-        mem = get_gpu_available_memory()
-        device_id = np.argmin(mem) if type(mem) is list else 0
-        print(f"[info] gpu device {device_id} with minimum memory")
+        mem = get_mem_from_visible_gpus()
+        device_id = np.argmin(mem)
+        print(f"[info] gpu device {device_id} with minimum memory in {mem}")
 
         mem = min(mem) if type(mem) is list else mem
         mem = round(float(mem) / 1024.0)
@@ -288,6 +287,7 @@ class Segresnet2dAlgo(BundleAlgo):
                 "validation_data_device", ["cpu", "gpu"]
             )
             device_factor = 2.0 if validation_data_device == "gpu" else 1.0
+            ps_environ = os.environ.copy()  # ensure the CUDA_VISIBLE_DEVICES is copied when used.
 
             try:
                 cmd = "python {0:s}dummy_runner.py ".format(
@@ -300,7 +300,7 @@ class Segresnet2dAlgo(BundleAlgo):
                 cmd += f"--num_images_per_batch {num_images_per_batch} "
                 cmd += f"--num_sw_batch_size {num_sw_batch_size} "
                 cmd += f"--validation_data_device {validation_data_device}"
-                _ = subprocess.run(cmd.split(), check=True)
+                _ = subprocess.run(cmd.split(), env=ps_environ, check=True)
             except RuntimeError as e:
                 if "out of memory" in str(e):
                     return (

--- a/auto3dseg/algorithm_templates/segresnet2d/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/segresnet2d/scripts/algo.py
@@ -267,7 +267,7 @@ class Segresnet2dAlgo(BundleAlgo):
 
         mem = get_mem_from_visible_gpus()
         device_id = np.argmin(mem)
-        print(f"[info] gpu device {device_id} with minimum memory in {mem}")
+        print(f"[info] device {device_id} in visible GPU list has the minimum memory.")
 
         mem = min(mem) if type(mem) is list else mem
         mem = round(float(mem) / 1024.0)

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
@@ -13,6 +13,7 @@ import numpy as np
 import os
 import subprocess
 import sys
+import torch
 import yaml
 
 from copy import deepcopy
@@ -20,13 +21,11 @@ from monai.apps.auto3dseg import BundleAlgo
 from monai.bundle import ConfigParser
 
 
-def get_gpu_available_memory():
-    command = "nvidia-smi --query-gpu=memory.free --format=csv"
-    memory_free_info = (
-        subprocess.check_output(command.split()).decode("ascii").split("\n")[:-1][1:]
-    )
-    memory_free_values = [int(x.split()[0]) for i, x in enumerate(memory_free_info)]
-    return memory_free_values
+def get_mem_from_visible_gpus():
+    available_mem_visible_gpus = []
+    for d in range(torch.cuda.device_count()):
+        available_mem_visible_gpus.append(torch.cuda.mem_get_info(device=d)[0])
+    return available_mem_visible_gpus
 
 
 class SwinunetrAlgo(BundleAlgo):
@@ -221,9 +220,9 @@ class SwinunetrAlgo(BundleAlgo):
             if "range_num_sw_batch_size" in specs:
                 range_num_sw_batch_size = specs["range_num_sw_batch_size"]
 
-        mem = get_gpu_available_memory()
-        device_id = np.argmin(mem) if type(mem) is list else 0
-        print(f"[info] gpu device {device_id} with minimum memory")
+        mem = get_mem_from_visible_gpus()
+        device_id = np.argmin(mem)
+        print(f"[info] gpu device {device_id} with minimum memory in {mem}")
 
         mem = min(mem) if type(mem) is list else mem
         mem = round(float(mem) / 1024.0)
@@ -243,6 +242,7 @@ class SwinunetrAlgo(BundleAlgo):
                 "validation_data_device", ["cpu", "gpu"]
             )
             device_factor = 2.0 if validation_data_device == "gpu" else 1.0
+            ps_environ = os.environ.copy()  # ensure the CUDA_VISIBLE_DEVICES is copied when used.
 
             try:
                 cmd = "python {0:s}dummy_runner.py ".format(
@@ -255,7 +255,7 @@ class SwinunetrAlgo(BundleAlgo):
                 cmd += f"--num_images_per_batch {num_images_per_batch} "
                 cmd += f"--num_sw_batch_size {num_sw_batch_size} "
                 cmd += f"--validation_data_device {validation_data_device}"
-                _ = subprocess.run(cmd.split(), check=True)
+                _ = subprocess.run(cmd.split(), env=ps_environ, check=True)
             except RuntimeError as e:
                 if "out of memory" in str(e):
                     return (

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
@@ -222,7 +222,7 @@ class SwinunetrAlgo(BundleAlgo):
 
         mem = get_mem_from_visible_gpus()
         device_id = np.argmin(mem)
-        print(f"[info] gpu device {device_id} with minimum memory in {mem}")
+        print(f"[info] device {device_id} in visible GPU list has the minimum memory.")
 
         mem = min(mem) if type(mem) is list else mem
         mem = round(float(mem) / 1024.0)

--- a/auto3dseg/tests/test_algo_templates.py
+++ b/auto3dseg/tests/test_algo_templates.py
@@ -22,6 +22,7 @@ import shutil
 from monai.apps.auto3dseg import AlgoEnsembleBestByFold, AlgoEnsembleBestN, AlgoEnsembleBuilder, BundleGen, DataAnalyzer
 from monai.bundle.config_parser import ConfigParser
 from monai.data import create_test_image_3d
+from monai.utils.enums import AlgoKeys
 
 sim_datalist = {
     "testing": [
@@ -123,9 +124,9 @@ def auto_run(work_dir, data_src_cfg, algos):
     bundle_generator.generate(work_dir, num_fold=1)
     history = bundle_generator.get_history()
 
-    for h in history:
-        for name, algo in h.items():
-            algo.train(train_param)
+    for algo_dict in history:
+        algo = algo_dict[AlgoKeys.ALGO]
+        algo.train(train_param)
 
     builder = AlgoEnsembleBuilder(history, data_src_cfg_file)
     builder.set_ensemble_method(AlgoEnsembleBestN(n_best=len(history)))  # inference all models

--- a/auto3dseg/tests/test_gpu_customization.py
+++ b/auto3dseg/tests/test_gpu_customization.py
@@ -22,6 +22,7 @@ import shutil
 from monai.apps.auto3dseg import AlgoEnsembleBestByFold, AlgoEnsembleBestN, AlgoEnsembleBuilder, BundleGen, DataAnalyzer
 from monai.bundle.config_parser import ConfigParser
 from monai.data import create_test_image_3d
+from monai.utils.enums import AlgoKeys
 
 sim_datalist = {
     "testing": [
@@ -55,7 +56,6 @@ num_epochs_per_validation = 1
 num_warmup_epochs = 1
 
 train_param = {
-    "CUDA_VISIBLE_DEVICES": [x for x in range(num_gpus)],
     "num_epochs_per_validation": num_epochs_per_validation,
     "num_images_per_batch": num_images_per_batch,
     "num_epochs": num_epochs,
@@ -131,9 +131,9 @@ def auto_run(work_dir, data_src_cfg, algos):
     )
     history = bundle_generator.get_history()
 
-    for h in history:
-        for name, algo in h.items():
-            algo.train(train_param)
+    for algo_dict in history:
+        algo = algo_dict[AlgoKeys.ALGO]
+        algo.train(train_param)
 
     builder = AlgoEnsembleBuilder(history, data_src_cfg_file)
     builder.set_ensemble_method(AlgoEnsembleBestN(n_best=len(history)))  # inference all models


### PR DESCRIPTION
This PR aims to fix the [integration issue](https://github.com/Project-MONAI/MONAI/issues/6247).

The issue is caused when `gpu:0` is not used, for example, under an environment variable of `CUDA_VISIBLE_DEVICES=1,2`. In such case, `cuda` in `pytorch` only finds `gpu:1` and `gpu:2`, and index them as `cuda:0`, `cuda:1` in the subprocess call. However, `nvidia-smi` will be able to see all gpus. When a gpu is selected, there is a mismatch between the one that `nvidia-smi` finds and the one `pytorch` can see.

This PR uses `torch.cuda.mem_get_info` instead of `nvidia-smi` to find the available memory from GPUs visible to `cuda` and `pytorch`. But the limitation is that this function API is available **only after PyTorch 1.11**, which means we need to skip the integration in prior versions.