### PR TITLE
github action to upload algo templates to the release assets

### DIFF
--- a/.github/workflows/packaging-algo.yml
+++ b/.github/workflows/packaging-algo.yml
@@ -1,5 +1,5 @@
 name: release
-# generating and testing package artefacts from the main branch
+# generating package artefacts from the main branch
 
 on:
   workflow_dispatch:
@@ -8,12 +8,10 @@ on:
         description: 'The tag to upload this asset into'
         required: true
         default: 'algo_templates'
-  push:
-    branches:
-      - auto-upload
 
 jobs:
   packaging-algo:
+    if: github.repository == 'Project-MONAI/research-contributions'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -33,8 +31,7 @@ jobs:
     - name: Upload ${{ steps.name.outputs.sha_short }}
       uses: svenstaro/upload-release-action@v2
       with:
-        # tag: ${{ github.event.inputs.tag_name }}
-        tag: algo_templates_test
+        tag: ${{ github.event.inputs.tag_name }}
         file: auto3dseg/${{ steps.name.outputs.sha_short }}.tar.gz
         asset_name: ${{ steps.name.outputs.sha_short }}.tar.gz
         overwrite: false

--- a/.github/workflows/packaging-algo.yml
+++ b/.github/workflows/packaging-algo.yml
@@ -3,6 +3,11 @@ name: release
 
 on:
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'The tag to upload this asset into'
+        required: true
+        default: 'algo_templates'
   push:
     branches:
       - auto-upload
@@ -28,7 +33,13 @@ jobs:
     - name: Upload ${{ steps.name.outputs.sha_short }}
       uses: svenstaro/upload-release-action@v2
       with:
+        # tag: ${{ github.event.inputs.tag_name }}
         tag: algo_templates_test
         file: auto3dseg/${{ steps.name.outputs.sha_short }}.tar.gz
         asset_name: ${{ steps.name.outputs.sha_short }}.tar.gz
         overwrite: false
+    - name: Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ steps.name.outputs.sha_short }}
+        path: auto3dseg/${{ steps.name.outputs.sha_short }}.tar.gz

--- a/.github/workflows/packaging-algo.yml
+++ b/.github/workflows/packaging-algo.yml
@@ -18,14 +18,14 @@ jobs:
     - name: Algo name
       id: name
       run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-    - name: Build
+    - name: Build ${{ steps.name.outputs.sha_short }}
       env:
         release_version: ${{ steps.name.outputs.sha_short }}
       run: |
         echo $release_version
         cd auto3dseg/
         tar -cvzf "$release_version".tar.gz algorithm_templates
-    - name: Upload
+    - name: Upload ${{ steps.name.outputs.sha_short }}
       uses: svenstaro/upload-release-action@v2
       with:
         tag: algo_templates_test

--- a/.github/workflows/packaging-algo.yml
+++ b/.github/workflows/packaging-algo.yml
@@ -3,6 +3,9 @@ name: release
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - auto-upload
 
 jobs:
   packaging-algo:
@@ -23,7 +26,8 @@ jobs:
         cd auto3dseg/
         tar -cvzf "$release_version".tar.gz algorithm_templates
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: svenstaro/upload-release-action@v2
       with:
-        name: ${{ steps.name.outputs.sha_short }}
-        path: auto3dseg/${{ steps.name.outputs.sha_short }}.tar.gz
+        tag: algo_templates_test
+        asset_name: ${{ steps.name.outputs.sha_short }}.tar.gz
+        overwrite: false

--- a/.github/workflows/packaging-algo.yml
+++ b/.github/workflows/packaging-algo.yml
@@ -29,5 +29,6 @@ jobs:
       uses: svenstaro/upload-release-action@v2
       with:
         tag: algo_templates_test
+        file: auto3dseg/${{ steps.name.outputs.sha_short }}.tar.gz
         asset_name: ${{ steps.name.outputs.sha_short }}.tar.gz
         overwrite: false


### PR DESCRIPTION
tested https://github.com/Project-MONAI/research-contributions/actions/runs/4925546389

this workflow is manually dispatched and by default will upload the tar.gz file to `algo_templates` https://github.com/Project-MONAI/research-contributions/releases/tag/algo_templates

cc @mingxin-zheng 