### PR TITLE
auto3dseg - dints - fix list input for dataset keys

### DIFF
--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -78,6 +78,13 @@ class DintsAlgo(BundleAlgo):
             except BaseException:
                 pass
 
+            try:
+                if isinstance(data_src_cfg["sigmoid"], bool) and data_src_cfg["sigmoid"] == True:
+                    hyper_parameters.update({"training#softmax": False})
+                    hyper_parameters_search.update({"searching#softmax": False})
+            except BaseException:
+                pass
+
             input_channels = data_stats["stats_summary#image_stats#channels#max"]
             output_classes = len(data_stats["stats_summary#label_stats#labels"])
 

--- a/auto3dseg/algorithm_templates/dints/scripts/infer.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/infer.py
@@ -142,7 +142,11 @@ class InferClass:
             infer_ds = monai.data.Dataset(data=self.infer_files, transform=self.infer_transforms)
             self.infer_loader = ThreadDataLoader(infer_ds, num_workers=8, batch_size=1, shuffle=False)
 
-        self.device = torch.device("cuda:0")
+        try:
+            device = f"cuda:{dist.get_rank()}"
+        except BaseException:
+            device = f"cuda:0"
+        self.device = device
 
         self.model = parser.get_parsed_content("training_network#network")
         self.model = self.model.to(self.device)

--- a/auto3dseg/algorithm_templates/dints/scripts/infer.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/infer.py
@@ -15,6 +15,7 @@ import sys
 from typing import Optional, Sequence, Union
 
 import torch
+import torch.distributed as dist
 
 import monai
 from monai import transforms

--- a/auto3dseg/algorithm_templates/dints/scripts/infer.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/infer.py
@@ -20,6 +20,7 @@ import monai
 from monai import transforms
 from monai.apps.auto3dseg.auto_runner import logger
 from monai.apps.utils import DEFAULT_FMT
+from monai.auto3dseg.utils import datafold_read
 from monai.bundle import ConfigParser
 from monai.bundle.scripts import _pop_args, _update_args
 from monai.data import ThreadDataLoader, decollate_batch, list_data_collate
@@ -131,22 +132,10 @@ class InferClass:
 
         self.infer_transforms = parser.get_parsed_content("transforms_infer")
 
-        datalist = ConfigParser.load_config_file(data_list_file_path)
-
-        list_data = []
-        for item in datalist[data_list_key]:
-            list_data.append(item)
-
-        files = []
-        for _i in range(len(list_data)):
-            str_img = os.path.join(data_file_base_dir, list_data[_i]["image"])
-
-            if not os.path.exists(str_img):
-                continue
-
-            files.append({"image": str_img})
-
-        self.infer_files = files
+        testing_files, _ = datafold_read(
+            datalist=data_list_file_path, basedir=data_file_base_dir, fold=-1, key="testing"
+        )
+        self.infer_files = testing_files
 
         self.infer_loader = None
         if self.fast:

--- a/auto3dseg/algorithm_templates/dints/scripts/train.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/train.py
@@ -36,6 +36,7 @@ import monai
 from monai import transforms
 from monai.apps.auto3dseg.auto_runner import logger
 from monai.apps.utils import DEFAULT_FMT
+from monai.auto3dseg.utils import datafold_read
 from monai.bundle import ConfigParser
 from monai.bundle.scripts import _pop_args, _update_args
 from monai.data import DataLoader, partition_dataset
@@ -279,17 +280,10 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
             item.pop("fold", None)
             list_train.append(item)
 
-    files = []
-    for _i in range(len(list_train)):
-        str_img = os.path.join(data_file_base_dir, list_train[_i]["image"])
-        str_seg = os.path.join(data_file_base_dir, list_train[_i]["label"])
+    train_files, val_files = datafold_read(
+        datalist=data_list_file_path, basedir=data_file_base_dir, fold=fold
+    )
 
-        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
-            continue
-
-        files.append({"image": str_img, "label": str_seg})
-
-    train_files = files
     random.shuffle(train_files)
 
     if torch.cuda.device_count() > 1:
@@ -297,18 +291,6 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
             dist.get_rank()
         ]
     logger.debug(f"train_files: {len(train_files)}")
-
-    files = []
-    for _i in range(len(list_valid)):
-        str_img = os.path.join(data_file_base_dir, list_valid[_i]["image"])
-        str_seg = os.path.join(data_file_base_dir, list_valid[_i]["label"])
-
-        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
-            continue
-
-        files.append({"image": str_img, "label": str_seg})
-
-    val_files = files
 
     if torch.cuda.device_count() > 1:
         if len(val_files) < world_size:

--- a/auto3dseg/algorithm_templates/dints/scripts/train.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/train.py
@@ -268,18 +268,6 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
     CONFIG["handlers"]["file"]["filename"] = log_output_file
     logging.config.dictConfig(CONFIG)
 
-    datalist = ConfigParser.load_config_file(data_list_file_path)
-
-    list_train = []
-    list_valid = []
-    for item in datalist["training"]:
-        if item["fold"] == fold:
-            item.pop("fold", None)
-            list_valid.append(item)
-        else:
-            item.pop("fold", None)
-            list_train.append(item)
-
     train_files, val_files = datafold_read(
         datalist=data_list_file_path, basedir=data_file_base_dir, fold=fold
     )

--- a/auto3dseg/algorithm_templates/dints/scripts/validate.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/validate.py
@@ -144,14 +144,6 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
         ]
     )
 
-    datalist = ConfigParser.load_config_file(data_list_file_path)
-
-    list_valid = []
-    for item in datalist["training"]:
-        if item["fold"] == fold:
-            item.pop("fold", None)
-            list_valid.append(item)
-
     _, val_files = datafold_read(
         datalist=data_list_file_path, basedir=data_file_base_dir, fold=fold
     )

--- a/auto3dseg/algorithm_templates/dints/scripts/validate.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/validate.py
@@ -23,6 +23,7 @@ import monai
 from monai import transforms
 from monai.apps.auto3dseg.auto_runner import logger
 from monai.apps.utils import DEFAULT_FMT
+from monai.auto3dseg.utils import datafold_read
 from monai.bundle import ConfigParser
 from monai.bundle.scripts import _pop_args, _update_args
 from monai.data import ThreadDataLoader, decollate_batch
@@ -151,17 +152,9 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
             item.pop("fold", None)
             list_valid.append(item)
 
-    files = []
-    for _i in range(len(list_valid)):
-        str_img = os.path.join(data_file_base_dir, list_valid[_i]["image"])
-        str_seg = os.path.join(data_file_base_dir, list_valid[_i]["label"])
-
-        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
-            continue
-
-        files.append({"image": str_img, "label": str_seg})
-
-    val_files = files
+    _, val_files = datafold_read(
+        datalist=data_list_file_path, basedir=data_file_base_dir, fold=fold
+    )
 
     val_ds = monai.data.Dataset(data=val_files, transform=validate_transforms)
     val_loader = ThreadDataLoader(val_ds, num_workers=2, batch_size=1, shuffle=False)

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
@@ -95,6 +95,13 @@ class SwinunetrAlgo(BundleAlgo):
                 max(64, shape_k // 64 * 64) if shape_k < p_k else p_k for p_k, shape_k in zip(patch_size, max_shape)
             ]
 
+            try:
+                if isinstance(data_src_cfg["sigmoid"], bool) and data_src_cfg["sigmoid"] == True:
+                    hyper_parameters.update({"training#softmax": False})
+                    hyper_parameters_search.update({"searching#softmax": False})
+            except BaseException:
+                pass
+
             input_channels = data_stats["stats_summary#image_stats#channels#max"]
             output_classes = len(data_stats["stats_summary#label_stats#labels"])
             n_cases = data_stats["stats_summary#n_cases"]

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/infer.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/infer.py
@@ -20,6 +20,7 @@ import torch.distributed as dist
 import monai
 from monai import transforms
 from monai.apps.auto3dseg.auto_runner import logger
+from monai.auto3dseg.utils import datafold_read
 from monai.bundle import ConfigParser
 from monai.bundle.scripts import _pop_args, _update_args
 from monai.data import ThreadDataLoader, decollate_batch, list_data_collate
@@ -64,22 +65,10 @@ class InferClass:
         logging.config.dictConfig(CONFIG)
         self.infer_transforms = parser.get_parsed_content("transforms_infer")
 
-        datalist = ConfigParser.load_config_file(data_list_file_path)
-
-        list_data = []
-        for item in datalist[data_list_key]:
-            list_data.append(item)
-
-        files = []
-        for _i in range(len(list_data)):
-            str_img = os.path.join(data_file_base_dir, list_data[_i]["image"])
-
-            if not os.path.exists(str_img):
-                continue
-
-            files.append({"image": str_img})
-
-        self.infer_files = files
+        testing_files, _ = datafold_read(
+            datalist=data_list_file_path, basedir=data_file_base_dir, fold=-1, key="testing"
+        )
+        self.infer_files = testing_files
 
         self.infer_loader = None
         if self.fast:

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
@@ -38,6 +38,7 @@ from monai import transforms
 from monai.apps import download_url
 from monai.apps.auto3dseg.auto_runner import logger
 from monai.apps.utils import DEFAULT_FMT
+from monai.auto3dseg.utils import datafold_read
 from monai.bundle import ConfigParser
 from monai.bundle.scripts import _pop_args, _update_args
 from monai.data import DataLoader, partition_dataset
@@ -217,29 +218,10 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
     logger.debug(f"Number of GPUs: {torch.cuda.device_count()}")
     logger.debug(f"World_size: {world_size}")
 
-    datalist = ConfigParser.load_config_file(data_list_file_path)
+    train_files, val_files = datafold_read(
+        datalist=data_list_file_path, basedir=data_file_base_dir, fold=fold
+    )
 
-    list_train = []
-    list_valid = []
-    for item in datalist["training"]:
-        if item["fold"] == fold:
-            item.pop("fold", None)
-            list_valid.append(item)
-        else:
-            item.pop("fold", None)
-            list_train.append(item)
-
-    files = []
-    for _i in range(len(list_train)):
-        str_img = os.path.join(data_file_base_dir, list_train[_i]["image"])
-        str_seg = os.path.join(data_file_base_dir, list_train[_i]["label"])
-
-        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
-            continue
-
-        files.append({"image": str_img, "label": str_seg})
-
-    train_files = files
     random.shuffle(train_files)
 
     if torch.cuda.device_count() > 1:
@@ -247,18 +229,6 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
             dist.get_rank()
         ]
     logger.debug(f"Train_files: {len(train_files)}")
-
-    files = []
-    for _i in range(len(list_valid)):
-        str_img = os.path.join(data_file_base_dir, list_valid[_i]["image"])
-        str_seg = os.path.join(data_file_base_dir, list_valid[_i]["label"])
-
-        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
-            continue
-
-        files.append({"image": str_img, "label": str_seg})
-
-    val_files = files
 
     if torch.cuda.device_count() > 1:
         if len(val_files) < world_size:

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/validate.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/validate.py
@@ -22,6 +22,7 @@ import yaml
 import monai
 from monai import transforms
 from monai.apps.auto3dseg.auto_runner import logger
+from monai.auto3dseg.utils import datafold_read
 from monai.bundle import ConfigParser
 from monai.bundle.scripts import _pop_args, _update_args
 from monai.data import ThreadDataLoader, decollate_batch
@@ -76,25 +77,9 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
         ]
     )
 
-    datalist = ConfigParser.load_config_file(data_list_file_path)
-
-    list_valid = []
-    for item in datalist["training"]:
-        if item["fold"] == fold:
-            item.pop("fold", None)
-            list_valid.append(item)
-
-    files = []
-    for _i in range(len(list_valid)):
-        str_img = os.path.join(data_file_base_dir, list_valid[_i]["image"])
-        str_seg = os.path.join(data_file_base_dir, list_valid[_i]["label"])
-
-        if (not os.path.exists(str_img)) or (not os.path.exists(str_seg)):
-            continue
-
-        files.append({"image": str_img, "label": str_seg})
-
-    val_files = files
+    _, val_files = datafold_read(
+        datalist=data_list_file_path, basedir=data_file_base_dir, fold=fold
+    )
 
     val_ds = monai.data.Dataset(data=val_files, transform=validate_transforms)
     val_loader = ThreadDataLoader(val_ds, num_workers=2, batch_size=1, shuffle=False)


### PR DESCRIPTION
Addressed issues arising when running benchmark experiments.

1. Allowed DiNTS algorithm to take list input;
2. Allowed SwinUNETR algorithm to take list input;
3. Updated DiNTS inference scripts for multi-GPU setting;
4. Allowed DiNTS algorithm to take optional input "sigmoid" in the `input.yaml`;
5. Allowed SwinUNETR algorithm to take optional input "sigmoid" in the `input.yaml`.