### PR TITLE
[auto3dseg] rectified Out of Memory (OOM) errors and timeouts within the dints algorithm

### DIFF
--- a/auto3dseg/algorithm_templates/dints/configs/hyper_parameters.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/hyper_parameters.yaml
@@ -20,7 +20,8 @@ training:
   num_epochs_per_validation: 2
   num_patches_per_image: 1
   num_patches_per_iter: 1
-  num_sw_batch_size: "$@training#num_patches_per_iter"
+  # num_sw_batch_size: "$@training#num_patches_per_iter"
+  num_sw_batch_size: null
   num_workers: 8
   num_workers_validation: 2
   num_cache_workers: 8

--- a/auto3dseg/algorithm_templates/dints/configs/hyper_parameters.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/hyper_parameters.yaml
@@ -20,7 +20,6 @@ training:
   num_epochs_per_validation: 2
   num_patches_per_image: 1
   num_patches_per_iter: 1
-  # num_sw_batch_size: "$@training#num_patches_per_iter"
   num_sw_batch_size: null
   num_workers: 8
   num_workers_validation: 2

--- a/auto3dseg/algorithm_templates/dints/scripts/train.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/train.py
@@ -610,7 +610,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
                                 val_images = val_data["image"].to(_device_in)
                                 val_labels = val_data["label"].to(_device_out)
 
-                                if num_sw_batch_size == None:
+                                if num_sw_batch_size is None:
                                     sw_batch_size = num_patches_per_iter * 12 if _device_out == "cpu" else 1
                                 else:
                                     sw_batch_size = num_sw_batch_size
@@ -773,7 +773,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
                             val_images = val_data["image"].to(_device_in)
                             val_labels = val_data["label"].to(_device_out)
 
-                            if num_sw_batch_size == None:
+                            if num_sw_batch_size is None:
                                 sw_batch_size = num_patches_per_iter * 12 if _device_out == "cpu" else 1
                             else:
                                 sw_batch_size = num_sw_batch_size


### PR DESCRIPTION
Rectified Out of Memory (OOM) errors and timeouts within the dints algorithm.

- Rectified Out of Memory (OOM) errors;
- Extended the timeout duration to avoid any synchronization anomalies during multi-GPU model training/validation;
- Optimized the batch size setting of sliding-window inferer for different devices;
- Refined the codebase.