### PR TITLE
[auto3dseg] adjust the number of training epochs in dints

### DIFF
--- a/auto3dseg/algorithm_templates/dints/scripts/infer.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/infer.py
@@ -99,7 +99,6 @@ def pre_operation(config_file, **override):
                     try:
                         _factor *= 1251.0 / float(parser["stats_summary"]["n_cases"])
                         _mean_shape = parser["stats_summary"]["image_stats"]["shape"]["mean"]
-                        print("_mean_shape", _mean_shape)
                         _factor *= float(_mean_shape[0]) / 240.0
                         _factor *= float(_mean_shape[1]) / 240.0
                         _factor *= float(_mean_shape[2]) / 155.0

--- a/auto3dseg/algorithm_templates/dints/scripts/infer.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/infer.py
@@ -92,7 +92,32 @@ def pre_operation(config_file, **override):
 
                     parser["training"].update({"num_patches_per_iter": batch_size})
                     parser["training"].update({"num_patches_per_image": 2 * batch_size})
-                    parser["training"].update({"num_epochs": int(400.0 / float(batch_size))})
+
+                    # estimate data size based on number of images and image size
+                    _factor = 1.0
+                    
+                    try:
+                        _factor *= 1251.0 / float(parser["stats_summary"]["n_cases"])
+                        _mean_shape = parser["stats_summary"]["image_stats"]["shape"]["mean"]
+                        print("_mean_shape", _mean_shape)
+                        _factor *= float(_mean_shape[0]) / 240.0
+                        _factor *= float(_mean_shape[1]) / 240.0
+                        _factor *= float(_mean_shape[2]) / 155.0
+                    except BaseException:
+                        pass
+                    
+                    _patch_size = parser["training"]["patch_size"]
+                    _factor *= 96.0 / float(_patch_size[0])
+                    _factor *= 96.0 / float(_patch_size[1])
+                    _factor *= 96.0 / float(_patch_size[2])
+
+                    _factor /= 6.0
+                    _factor = max(1.0, _factor)
+
+                    _estimated_epochs = 400.0
+                    _estimated_epochs *= _factor
+
+                    parser["training"].update({"num_epochs": int(_estimated_epochs / float(batch_size))})
 
                     ConfigParser.export_config_file(parser.get(), _file, fmt="yaml", default_flow_style=None)
 

--- a/auto3dseg/algorithm_templates/dints/scripts/infer.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/infer.py
@@ -95,7 +95,7 @@ def pre_operation(config_file, **override):
 
                     # estimate data size based on number of images and image size
                     _factor = 1.0
-                    
+
                     try:
                         _factor *= 1251.0 / float(parser["stats_summary"]["n_cases"])
                         _mean_shape = parser["stats_summary"]["image_stats"]["shape"]["mean"]
@@ -104,7 +104,7 @@ def pre_operation(config_file, **override):
                         _factor *= float(_mean_shape[2]) / 155.0
                     except BaseException:
                         pass
-                    
+
                     _patch_size = parser["training"]["patch_size"]
                     _factor *= 96.0 / float(_patch_size[0])
                     _factor *= 96.0 / float(_patch_size[1])

--- a/auto3dseg/algorithm_templates/dints/scripts/train.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/train.py
@@ -151,7 +151,32 @@ def pre_operation(config_file, **override):
 
                     parser["training"].update({"num_patches_per_iter": batch_size})
                     parser["training"].update({"num_patches_per_image": 2 * batch_size})
-                    parser["training"].update({"num_epochs": int(400.0 / float(batch_size))})
+
+                    # estimate data size based on number of images and image size
+                    _factor = 1.0
+                    
+                    try:
+                        _factor *= 1251.0 / float(parser["stats_summary"]["n_cases"])
+                        _mean_shape = parser["stats_summary"]["image_stats"]["shape"]["mean"]
+                        print("_mean_shape", _mean_shape)
+                        _factor *= float(_mean_shape[0]) / 240.0
+                        _factor *= float(_mean_shape[1]) / 240.0
+                        _factor *= float(_mean_shape[2]) / 155.0
+                    except BaseException:
+                        pass
+                    
+                    _patch_size = parser["training"]["patch_size"]
+                    _factor *= 96.0 / float(_patch_size[0])
+                    _factor *= 96.0 / float(_patch_size[1])
+                    _factor *= 96.0 / float(_patch_size[2])
+
+                    _factor /= 6.0
+                    _factor = max(1.0, _factor)
+
+                    _estimated_epochs = 400.0
+                    _estimated_epochs *= _factor
+
+                    parser["training"].update({"num_epochs": int(_estimated_epochs / float(batch_size))})
 
                     ConfigParser.export_config_file(parser.get(), _file, fmt="yaml", default_flow_style=None)
 

--- a/auto3dseg/algorithm_templates/dints/scripts/train.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/train.py
@@ -154,7 +154,7 @@ def pre_operation(config_file, **override):
 
                     # estimate data size based on number of images and image size
                     _factor = 1.0
-                    
+
                     try:
                         _factor *= 1251.0 / float(parser["stats_summary"]["n_cases"])
                         _mean_shape = parser["stats_summary"]["image_stats"]["shape"]["mean"]
@@ -163,7 +163,7 @@ def pre_operation(config_file, **override):
                         _factor *= float(_mean_shape[2]) / 155.0
                     except BaseException:
                         pass
-                    
+
                     _patch_size = parser["training"]["patch_size"]
                     _factor *= 96.0 / float(_patch_size[0])
                     _factor *= 96.0 / float(_patch_size[1])

--- a/auto3dseg/algorithm_templates/dints/scripts/train.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/train.py
@@ -158,7 +158,6 @@ def pre_operation(config_file, **override):
                     try:
                         _factor *= 1251.0 / float(parser["stats_summary"]["n_cases"])
                         _mean_shape = parser["stats_summary"]["image_stats"]["shape"]["mean"]
-                        print("_mean_shape", _mean_shape)
                         _factor *= float(_mean_shape[0]) / 240.0
                         _factor *= float(_mean_shape[1]) / 240.0
                         _factor *= float(_mean_shape[2]) / 155.0

--- a/auto3dseg/algorithm_templates/dints/scripts/validate.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/validate.py
@@ -97,7 +97,7 @@ def pre_operation(config_file, **override):
 
                     # estimate data size based on number of images and image size
                     _factor = 1.0
-                    
+
                     try:
                         _factor *= 1251.0 / float(parser["stats_summary"]["n_cases"])
                         _mean_shape = parser["stats_summary"]["image_stats"]["shape"]["mean"]
@@ -106,7 +106,7 @@ def pre_operation(config_file, **override):
                         _factor *= float(_mean_shape[2]) / 155.0
                     except BaseException:
                         pass
-                    
+
                     _patch_size = parser["training"]["patch_size"]
                     _factor *= 96.0 / float(_patch_size[0])
                     _factor *= 96.0 / float(_patch_size[1])

--- a/auto3dseg/algorithm_templates/dints/scripts/validate.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/validate.py
@@ -94,7 +94,32 @@ def pre_operation(config_file, **override):
 
                     parser["training"].update({"num_patches_per_iter": batch_size})
                     parser["training"].update({"num_patches_per_image": 2 * batch_size})
-                    parser["training"].update({"num_epochs": int(400.0 / float(batch_size))})
+
+                    # estimate data size based on number of images and image size
+                    _factor = 1.0
+                    
+                    try:
+                        _factor *= 1251.0 / float(parser["stats_summary"]["n_cases"])
+                        _mean_shape = parser["stats_summary"]["image_stats"]["shape"]["mean"]
+                        print("_mean_shape", _mean_shape)
+                        _factor *= float(_mean_shape[0]) / 240.0
+                        _factor *= float(_mean_shape[1]) / 240.0
+                        _factor *= float(_mean_shape[2]) / 155.0
+                    except BaseException:
+                        pass
+                    
+                    _patch_size = parser["training"]["patch_size"]
+                    _factor *= 96.0 / float(_patch_size[0])
+                    _factor *= 96.0 / float(_patch_size[1])
+                    _factor *= 96.0 / float(_patch_size[2])
+
+                    _factor /= 6.0
+                    _factor = max(1.0, _factor)
+
+                    _estimated_epochs = 400.0
+                    _estimated_epochs *= _factor
+
+                    parser["training"].update({"num_epochs": int(_estimated_epochs / float(batch_size))})
 
                     ConfigParser.export_config_file(parser.get(), _file, fmt="yaml", default_flow_style=None)
 

--- a/auto3dseg/algorithm_templates/dints/scripts/validate.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/validate.py
@@ -101,7 +101,6 @@ def pre_operation(config_file, **override):
                     try:
                         _factor *= 1251.0 / float(parser["stats_summary"]["n_cases"])
                         _mean_shape = parser["stats_summary"]["image_stats"]["shape"]["mean"]
-                        print("_mean_shape", _mean_shape)
                         _factor *= float(_mean_shape[0]) / 240.0
                         _factor *= float(_mean_shape[1]) / 240.0
                         _factor *= float(_mean_shape[2]) / 155.0


### PR DESCRIPTION
Dynamically adjusted the number of training epochs in dints

- Incorporated the details from the data summary into the training configuration settings;
- Adjusted the number of training epochs in accordance with the size of the dataset (number of images, image size).
