### PR TITLE
config rank filter

### DIFF
--- a/auto3dseg/algorithm_templates/dints/scripts/train.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/train.py
@@ -44,7 +44,7 @@ from monai.data import DataLoader, partition_dataset
 from monai.inferers import sliding_window_inference
 from monai.metrics import compute_dice
 from monai.networks.utils import pytorch_after
-from monai.utils import set_determinism
+from monai.utils import set_determinism, RankFilter
 
 try:
     from apex.contrib.clip_grad import clip_grad_norm_
@@ -73,7 +73,7 @@ CONFIG = {
     "loggers": {
         "monai.apps.auto3dseg.auto_runner": {"handlers": ["file", "console"], "level": "DEBUG", "propagate": False}
     },
-    "filters": {"rank_filter": {"{}": "__main__.RankFilter"}},
+    "filters": {"rank_filter": {"()": "__main__.RankFilter"}},
     "handlers": {
         "file": {
             "class": "logging.FileHandler",

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
@@ -44,7 +44,7 @@ from monai.bundle.scripts import _pop_args, _update_args
 from monai.data import DataLoader, partition_dataset
 from monai.inferers import sliding_window_inference
 from monai.metrics import compute_dice
-from monai.utils import set_determinism
+from monai.utils import set_determinism, RankFilter
 
 if __package__ in (None, ""):
     from algo import auto_scale

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
@@ -58,7 +58,7 @@ CONFIG = {
     "loggers": {
         "monai.apps.auto3dseg.auto_runner": {"handlers": ["file", "console"], "level": "DEBUG", "propagate": False}
     },
-    "filters": {"rank_filter": {"{}": "__main__.RankFilter"}},
+    "filters": {"rank_filter": {"()": "__main__.RankFilter"}},
     "handlers": {
         "file": {
             "class": "logging.FileHandler",


### PR DESCRIPTION
enable rankfiltering logging (based on https://stackoverflow.com/questions/21455515/install-filter-on-logging-level-in-python-using-dictconfig)

this requires the fix https://github.com/Project-MONAI/MONAI/issues/6894