### PR TITLE
[Auto3DSeg] Update SwinUNETR template

### DIFF
--- a/auto3dseg/algorithm_templates/swinunetr/configs/hyper_parameters.yaml
+++ b/auto3dseg/algorithm_templates/swinunetr/configs/hyper_parameters.yaml
@@ -17,6 +17,7 @@ amp: true
 input_channels: null
 learning_rate: 0.0004
 log_output_file: "$@bundle_root + '/model_fold' + str(@fold) + '/training.log'"
+mlflow_tracking_uri: "$@bundle_root + '/model_fold' + str(@fold) + '/mlruns/'"
 num_images_per_batch: 2
 num_epochs: null
 auto_scale_max_epochs: 1000

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
@@ -129,6 +129,9 @@ class SwinunetrAlgo(BundleAlgo):
             hyper_parameters.update({"output_classes": output_classes})
             hyper_parameters.update({"n_cases": n_cases})
 
+            if hasattr(self, "mlflow_tracking_uri") and self.mlflow_tracking_uri != None:
+                hyper_parameters.update({"mlflow_tracking_uri": self.mlflow_tracking_uri})
+
             modality = data_src_cfg.get("modality", "ct").lower()
             spacing = data_stats["stats_summary#image_stats#spacing#median"]
 

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
@@ -158,6 +158,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
     data_list_file_path = parser.get_parsed_content("data_list_file_path")
     finetune = parser.get_parsed_content("finetune")
     fold = parser.get_parsed_content("fold")
+    mlflow_tracking_uri = parser.get_parsed_content("mlflow_tracking_uri")
     num_images_per_batch = parser.get_parsed_content("num_images_per_batch")
     num_epochs = parser.get_parsed_content("num_epochs")
     num_epochs_per_validation = parser.get_parsed_content("num_epochs_per_validation")
@@ -401,7 +402,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
 
     if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
         writer = SummaryWriter(log_dir=os.path.join(ckpt_path, "Events"))
-        mlflow.set_tracking_uri(os.path.join(ckpt_path, "mlruns"))
+        mlflow.set_tracking_uri(mlflow_tracking_uri)
         mlflow.start_run(run_name=f'swinunetr - fold{fold} - train')
         with open(os.path.join(ckpt_path, "accuracy_history.csv"), "a") as f:
             f.write("epoch\tmetric\tloss\tlr\ttime\titer\n")

--- a/auto3dseg/metadata.json
+++ b/auto3dseg/metadata.json
@@ -1,6 +1,7 @@
 {
-    "version": "0.0.3",
+    "version": "0.0.4",
     "changelog": {
+        "0.0.4": "Enable support of mlflow in swinunetr algorithm template for public server.",
         "0.0.3": "update hyper-parameter naming and mlflow in swinunetr algorithm template.",
         "0.0.2": "update hyper-parameter naming in dints algorithm template.",
         "0.0.1": "this version is based on commit 03a6d4effb9223670f439c3a29198ef34938922f."


### PR DESCRIPTION
Update SwinUNETR template to enable `mlflow_tracking_uri`.
All integration tests passed.
Tested on MLflow server as well.