### PR TITLE
Support for MLFLow experiment name in algo templates

### DIFF
--- a/auto3dseg/algorithm_templates/dints/configs/hyper_parameters.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/hyper_parameters.yaml
@@ -6,6 +6,7 @@ data_list_file_path: null
 fold: 0
 
 mlflow_tracking_uri: "$@bundle_root + '/model_fold' + str(@fold) + '/mlruns/'"
+mlflow_experiment_name: "Auto3dSeg"
 show_cache_progress: false
 
 training:

--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -124,6 +124,9 @@ class DintsAlgo(BundleAlgo):
             if hasattr(self, "mlflow_tracking_uri") and self.mlflow_tracking_uri is not None:
                 hyper_parameters.update({"mlflow_tracking_uri": self.mlflow_tracking_uri})
 
+            if hasattr(self, "mlflow_experiment_name") and self.mlflow_experiment_name is not None:
+                hyper_parameters.update({"mlflow_experiment_name": self.mlflow_experiment_name})
+
             modality = data_src_cfg.get("modality", "ct").lower()
             spacing = data_stats["stats_summary#image_stats#spacing#median"]
 

--- a/auto3dseg/algorithm_templates/dints/scripts/train.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/train.py
@@ -241,6 +241,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
     fold = parser.get_parsed_content("fold")
     log_output_file = parser.get_parsed_content("training#log_output_file")
     mlflow_tracking_uri = parser.get_parsed_content("mlflow_tracking_uri")
+    mlflow_experiment_name = parser.get_parsed_content("mlflow_experiment_name")
     num_images_per_batch = parser.get_parsed_content("training#num_images_per_batch")
     num_epochs = parser.get_parsed_content("training#num_epochs")
     num_epochs_per_validation = parser.get_parsed_content("training#num_epochs_per_validation")
@@ -531,6 +532,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
         writer = SummaryWriter(log_dir=os.path.join(ckpt_path, "Events"))
 
         mlflow.set_tracking_uri(mlflow_tracking_uri)
+        mlflow.set_experiment(mlflow_experiment_name)
         mlflow.start_run(run_name=f"dints - fold{fold} - train")
 
         with open(os.path.join(ckpt_path, "accuracy_history.csv"), "a") as f:

--- a/auto3dseg/algorithm_templates/segresnet/configs/hyper_parameters.yaml
+++ b/auto3dseg/algorithm_templates/segresnet/configs/hyper_parameters.yaml
@@ -1,6 +1,7 @@
 bundle_root: null                           # root folder of the fold
 ckpt_path: $@bundle_root + '/model'         # location to save checkpoints and logs
 mlflow_tracking_uri: $@ckpt_path + '/mlruns/'
+mlflow_experiment_name: "Auto3dSeg"
 
 data_file_base_dir: null                    # location of the dataset
 data_list_file_path: null                   # location of the file with a list of files image/label in the dataset

--- a/auto3dseg/algorithm_templates/segresnet/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/segresnet/scripts/algo.py
@@ -265,6 +265,8 @@ class SegresnetAlgo(BundleAlgo):
             # mlflow
             if hasattr(self, "mlflow_tracking_uri") and self.mlflow_tracking_uri is not None:
                 config.update({"mlflow_tracking_uri": self.mlflow_tracking_uri})
+            if hasattr(self, "mlflow_experiment_name") and self.mlflow_experiment_name is not None:
+                config.update({"mlflow_experiment_name": self.mlflow_experiment_name})
 
             config.update(input_config)  # override if any additional inputs provided
             fill_records = {"hyper_parameters.yaml": config}

--- a/auto3dseg/algorithm_templates/segresnet/scripts/segmenter.py
+++ b/auto3dseg/algorithm_templates/segresnet/scripts/segmenter.py
@@ -1271,6 +1271,7 @@ class Segmenter:
 
             if mlflow_is_imported:
                 mlflow.set_tracking_uri(config["mlflow_tracking_uri"])
+                mlflow.set_experiment(config["mlflow_experiment_name"])
                 mlflow.start_run(run_name=f'segresnet - fold{config["fold"]} - train')
 
             csv_path = os.path.join(ckpt_path, "accuracy_history.csv")

--- a/auto3dseg/algorithm_templates/segresnet2d/configs/hyper_parameters.yaml
+++ b/auto3dseg/algorithm_templates/segresnet2d/configs/hyper_parameters.yaml
@@ -1,6 +1,7 @@
 bundle_root: null                           # root folder of the fold
 ckpt_path: $@bundle_root + '/model'         # location to save checkpoints and logs
 mlflow_tracking_uri: $@ckpt_path + '/mlruns/'
+mlflow_experiment_name: "Auto3dSeg"
 
 data_file_base_dir: null                    # location of the dataset
 data_list_file_path: null                   # location of the file with a list of files image/label in the dataset

--- a/auto3dseg/algorithm_templates/segresnet2d/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/segresnet2d/scripts/algo.py
@@ -290,6 +290,8 @@ class Segresnet2dAlgo(BundleAlgo):
             # mlflow
             if hasattr(self, "mlflow_tracking_uri") and self.mlflow_tracking_uri is not None:
                 config.update({"mlflow_tracking_uri": self.mlflow_tracking_uri})
+            if hasattr(self, "mlflow_experiment_name") and self.mlflow_experiment_name is not None:
+                config.update({"mlflow_experiment_name": self.mlflow_experiment_name})
 
             config.update(input_config)  # override if any additional inputs provided
             fill_records = {"hyper_parameters.yaml": config}

--- a/auto3dseg/algorithm_templates/segresnet2d/scripts/segmenter.py
+++ b/auto3dseg/algorithm_templates/segresnet2d/scripts/segmenter.py
@@ -1129,6 +1129,7 @@ class Segmenter:
 
             if mlflow_is_imported:
                 mlflow.set_tracking_uri(config["mlflow_tracking_uri"])
+                mlflow.set_experiment(config["mlflow_experiment_name"])
                 mlflow.start_run(run_name=f'segresnet - fold{config["fold"]} - train')
 
             csv_path = os.path.join(ckpt_path, "accuracy_history.csv")

--- a/auto3dseg/algorithm_templates/swinunetr/configs/hyper_parameters.yaml
+++ b/auto3dseg/algorithm_templates/swinunetr/configs/hyper_parameters.yaml
@@ -18,6 +18,7 @@ input_channels: null
 learning_rate: 0.0004
 log_output_file: "$@bundle_root + '/model_fold' + str(@fold) + '/training.log'"
 mlflow_tracking_uri: "$@bundle_root + '/model_fold' + str(@fold) + '/mlruns/'"
+mlflow_experiment_name: "Auto3dSeg"
 num_images_per_batch: 2
 num_epochs: null
 auto_scale_max_epochs: 1000

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
@@ -131,6 +131,8 @@ class SwinunetrAlgo(BundleAlgo):
 
             if hasattr(self, "mlflow_tracking_uri") and self.mlflow_tracking_uri is not None:
                 hyper_parameters.update({"mlflow_tracking_uri": self.mlflow_tracking_uri})
+            if hasattr(self, "mlflow_experiment_name") and self.mlflow_experiment_name is not None:
+                hyper_parameters.update({"mlflow_experiment_name": self.mlflow_experiment_name})
 
             modality = data_src_cfg.get("modality", "ct").lower()
             spacing = data_stats["stats_summary#image_stats#spacing#median"]

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/train.py
@@ -159,6 +159,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
     finetune = parser.get_parsed_content("finetune")
     fold = parser.get_parsed_content("fold")
     mlflow_tracking_uri = parser.get_parsed_content("mlflow_tracking_uri")
+    mlflow_experiment_name = parser.get_parsed_content("mlflow_experiment_name")
     num_images_per_batch = parser.get_parsed_content("num_images_per_batch")
     num_epochs = parser.get_parsed_content("num_epochs")
     num_epochs_per_validation = parser.get_parsed_content("num_epochs_per_validation")
@@ -403,6 +404,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
     if torch.cuda.device_count() == 1 or dist.get_rank() == 0:
         writer = SummaryWriter(log_dir=os.path.join(ckpt_path, "Events"))
         mlflow.set_tracking_uri(mlflow_tracking_uri)
+        mlflow.set_experiment(mlflow_experiment_name)
         mlflow.start_run(run_name=f"swinunetr - fold{fold} - train")
         with open(os.path.join(ckpt_path, "accuracy_history.csv"), "a") as f:
             f.write("epoch\tmetric\tloss\tlr\ttime\titer\n")


### PR DESCRIPTION
This PR adds `mlflow_experiment_name` to all auto3dseg algorithms that already supports MLFlow tracking URI.