### PR TITLE
Enable PyTorch 2.6+ in Auto3dseg

### DIFF
--- a/auto3dseg/algorithm_templates/dints/configs/network.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/network.yaml
@@ -1,7 +1,7 @@
 ---
 training_network:
   arch_ckpt_path: "$@bundle_root + '/scripts/arch_code.pth'"
-  arch_ckpt: "$torch.load(@training_network#arch_ckpt_path, map_location=torch.device('cuda'))"
+  arch_ckpt: "$torch.load(@training_network#arch_ckpt_path, map_location=torch.device('cuda'), weights_only=True)"
   dints_space:
     _target_: TopologyInstance
     channel_mul: 1

--- a/auto3dseg/algorithm_templates/dints/scripts/dummy_runner.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/dummy_runner.py
@@ -15,7 +15,7 @@ import fire
 import numpy as np
 import torch
 import yaml
-from torch.cuda.amp import GradScaler, autocast
+from torch.amp import GradScaler, autocast
 
 from monai.bundle import ConfigParser
 from monai.inferers import sliding_window_inference
@@ -74,7 +74,7 @@ class DummyRunnerDiNTS(object):
         print("max_shape", self.max_shape)
 
     def run(self, num_images_per_batch, num_sw_batch_size, validation_data_device):
-        scaler = GradScaler()
+        scaler = GradScaler("cuda")
 
         num_epochs = 2
         num_iterations = 6
@@ -122,7 +122,7 @@ class DummyRunnerDiNTS(object):
                 for param in self.model.parameters():
                     param.grad = None
 
-                with autocast():
+                with autocast(device_type="cuda"):
                     outputs = self.model(inputs)
                     loss = self.loss_function(outputs.float(), labels)
 
@@ -147,7 +147,7 @@ class DummyRunnerDiNTS(object):
                     if validation_data_device == "gpu":
                         val_images = val_images.to(self.device)
 
-                    with autocast():
+                    with autocast(device_type="cuda"):
                         val_outputs = sliding_window_inference(
                             val_images,
                             self.patch_size_valid,

--- a/auto3dseg/algorithm_templates/dints/scripts/infer.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/infer.py
@@ -203,7 +203,7 @@ class InferClass:
         self.model = parser.get_parsed_content("training_network#network")
         self.model = self.model.to(self.device)
 
-        pretrained_ckpt = torch.load(ckpt_name, map_location=self.device)
+        pretrained_ckpt = torch.load(ckpt_name, map_location=self.device, weights_only=True)
         self.model.load_state_dict(pretrained_ckpt)
         logger.debug(f"checkpoint {ckpt_name:s} loaded")
 
@@ -286,7 +286,7 @@ class InferClass:
                 else:
                     sw_batch_size = self.num_sw_batch_size
 
-                with torch.cuda.amp.autocast(enabled=self.amp):
+                with torch.autocast("cuda", enabled=self.amp):
                     batch_data["pred"] = sliding_window_inference(
                         inputs=infer_images,
                         roi_size=self.patch_size_valid,
@@ -352,7 +352,7 @@ class InferClass:
                         else:
                             sw_batch_size = self.num_sw_batch_size
 
-                        with torch.cuda.amp.autocast(enabled=self.amp):
+                        with torch.autocast("cuda", enabled=self.amp):
                             infer_data["pred"] = sliding_window_inference(
                                 inputs=infer_images,
                                 roi_size=self.patch_size_valid,

--- a/auto3dseg/algorithm_templates/dints/scripts/validate.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/validate.py
@@ -211,7 +211,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
     model = parser.get_parsed_content("training_network#network")
     model = model.to(device)
 
-    pretrained_ckpt = torch.load(ckpt_name, map_location=device)
+    pretrained_ckpt = torch.load(ckpt_name, map_location=device, weights_only=True)
     model.load_state_dict(pretrained_ckpt)
     logger.debug(f"checkpoint {ckpt_name:s} loaded")
 
@@ -295,7 +295,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
                     else:
                         sw_batch_size = num_sw_batch_size
 
-                    with torch.cuda.amp.autocast(enabled=amp):
+                    with torch.autocast("cuda", enabled=amp):
                         val_data["pred"] = sliding_window_inference(
                             inputs=val_images,
                             roi_size=patch_size_valid,

--- a/auto3dseg/algorithm_templates/segresnet/scripts/segmenter.py
+++ b/auto3dseg/algorithm_templates/segresnet/scripts/segmenter.py
@@ -811,6 +811,7 @@ class Segmenter:
             for ckpt_key in ["pretrained_ckpt_name", "validate#ckpt_name", "infer#ckpt_name", "finetune#ckpt_name"]:
                 ckpt = override.get(ckpt_key, None)
                 if ckpt and os.path.exists(ckpt):
+                    # weights_only=False to load the full checkpoint including config metadata
                     checkpoint = torch.load(ckpt, map_location="cpu", weights_only=False)
                     config = checkpoint.get("config", {})
                     if self.global_rank == 0:
@@ -1010,6 +1011,7 @@ class Segmenter:
             if self.global_rank == 0:
                 warnings.warn("Invalid checkpoint file: " + str(ckpt))
         else:
+            # weights_only=False to load the full checkpoint including config metadata
             checkpoint = torch.load(ckpt, map_location="cpu", weights_only=False)
             model.load_state_dict(checkpoint["state_dict"], strict=True)
             epoch = checkpoint.get("epoch", 0)

--- a/auto3dseg/algorithm_templates/segresnet2d/scripts/segmenter.py
+++ b/auto3dseg/algorithm_templates/segresnet2d/scripts/segmenter.py
@@ -31,7 +31,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import yaml
-from torch.cuda.amp import GradScaler, autocast
+from torch.amp import GradScaler, autocast
 from torch.nn.parallel import DistributedDataParallel
 from torch.utils.data.distributed import DistributedSampler
 from torch.utils.tensorboard import SummaryWriter
@@ -539,7 +539,7 @@ class Segmenter:
         self.loss_function = DeepSupervisionLoss(loss_function)
 
         self.acc_function = DiceHelper(sigmoid=config["sigmoid"])
-        self.grad_scaler = GradScaler(enabled=config["amp"])
+        self.grad_scaler = GradScaler("cuda", enabled=config["amp"])
 
         if config.get("sliding_inferrer") is not None:
             self.sliding_inferrer = ConfigParser(config["sliding_inferrer"]).get_parsed_content()
@@ -674,7 +674,7 @@ class Segmenter:
             for ckpt_key in ["pretrained_ckpt_name", "validate#ckpt_name", "infer#ckpt_name", "finetune#ckpt_name"]:
                 ckpt = override.get(ckpt_key, None)
                 if ckpt and os.path.exists(ckpt):
-                    checkpoint = torch.load(ckpt, map_location="cpu")
+                    checkpoint = torch.load(ckpt, map_location="cpu", weights_only=False)
                     config = checkpoint.get("config", {})
                     if self.global_rank == 0:
                         print(f"Initializing config from the checkpoint {ckpt}: {yaml.dump(config)}")
@@ -868,7 +868,7 @@ class Segmenter:
             if self.global_rank == 0:
                 warnings.warn("Invalid checkpoint file: " + str(ckpt))
         else:
-            checkpoint = torch.load(ckpt, map_location="cpu")
+            checkpoint = torch.load(ckpt, map_location="cpu", weights_only=False)
             model.load_state_dict(checkpoint["state_dict"], strict=True)
             epoch = checkpoint.get("epoch", 0)
             best_metric = checkpoint.get("best_metric", 0)
@@ -1611,7 +1611,7 @@ class Segmenter:
         memory_format = torch.channels_last_3d if channels_last else torch.preserve_format
         data = batch_data["image"].as_subclass(torch.Tensor).to(memory_format=memory_format, device=self.device)
 
-        with autocast(enabled=self.config["amp"]):
+        with autocast("cuda", enabled=self.config["amp"]):
             logits = self.sliding_inferrer(inputs=data, network=self.model)
 
         data = None
@@ -1687,7 +1687,7 @@ class Segmenter:
                 for param in model.parameters():
                     param.grad = None
 
-                with autocast(enabled=use_amp):
+                with autocast("cuda", enabled=use_amp):
                     logits = model(data)
 
                 loss = loss_function(logits, target)
@@ -1772,7 +1772,7 @@ class Segmenter:
             filename = batch_data["image"].meta[ImageMetaKey.FILENAME_OR_OBJ]
             batch_size = data.shape[0]
 
-            with autocast(enabled=use_amp):
+            with autocast("cuda", enabled=use_amp):
                 logits = sliding_inferrer(inputs=data, network=model)
 
             data = None

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/dummy_runner.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/dummy_runner.py
@@ -15,7 +15,7 @@ import fire
 import numpy as np
 import torch
 import yaml
-from torch.cuda.amp import GradScaler, autocast
+from torch.amp import GradScaler, autocast
 
 from monai.bundle import ConfigParser
 from monai.inferers import sliding_window_inference
@@ -74,7 +74,7 @@ class DummyRunnerSwinUNETR(object):
         print("max_shape", self.max_shape)
 
     def run(self, num_images_per_batch, num_sw_batch_size, validation_data_device):
-        scaler = GradScaler()
+        scaler = GradScaler("cuda")
 
         num_epochs = 2
         num_iterations = 6
@@ -122,7 +122,7 @@ class DummyRunnerSwinUNETR(object):
                 for param in self.model.parameters():
                     param.grad = None
 
-                with autocast():
+                with autocast("cuda"):
                     outputs = self.model(inputs)
                     loss = self.loss_function(outputs.float(), labels)
 
@@ -147,7 +147,7 @@ class DummyRunnerSwinUNETR(object):
                     if validation_data_device == "gpu":
                         val_images = val_images.to(self.device)
 
-                    with autocast():
+                    with autocast("cuda"):
                         val_outputs = sliding_window_inference(
                             val_images,
                             self.roi_size_valid,

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/infer.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/infer.py
@@ -91,7 +91,7 @@ class InferClass:
         self.model = parser.get_parsed_content("network")
         self.model = self.model.to(self.device)
 
-        pretrained_ckpt = torch.load(ckpt_name, map_location=self.device)
+        pretrained_ckpt = torch.load(ckpt_name, map_location=self.device, weights_only=True)
         self.model.load_state_dict(pretrained_ckpt)
         logger.debug(f"Checkpoint {ckpt_name:s} loaded.")
 
@@ -144,7 +144,7 @@ class InferClass:
             try:
                 logger.debug(f"Working on {image_file} on device {_device_in}/{_device_out} in/out.")
                 batch_data["pred"] = None
-                with torch.cuda.amp.autocast(enabled=self.amp):
+                with torch.autocast("cuda", enabled=self.amp):
                     batch_data["pred"] = sliding_window_inference(
                         inputs=batch_data["image"].to(_device_in),
                         roi_size=self.roi_size_valid,
@@ -189,7 +189,7 @@ class InferClass:
                 for _device_in, _device_out in zip(device_list_input, device_list_output):
                     try:
                         infer_images = d["image"].to(_device_in)
-                        with torch.cuda.amp.autocast(enabled=self.amp):
+                        with torch.autocast("cuda", enabled=self.amp):
                             d["pred"] = sliding_window_inference(
                                 inputs=infer_images,
                                 roi_size=self.roi_size_valid,

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/validate.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/validate.py
@@ -106,7 +106,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
     model = parser.get_parsed_content("network")
     model = model.to(device)
 
-    pretrained_ckpt = torch.load(ckpt_name, map_location=device)
+    pretrained_ckpt = torch.load(ckpt_name, map_location=device, weights_only=True)
     model.load_state_dict(pretrained_ckpt)
     logger.debug(f"Checkpoint {ckpt_name:s} loaded")
 
@@ -164,7 +164,7 @@ def run(config_file: Optional[Union[str, Sequence[str]]] = None, **override):
             for _device_in, _device_out in zip(device_list_input, device_list_output):
                 try:
                     val_data["pred"] = None
-                    with torch.cuda.amp.autocast(enabled=amp):
+                    with torch.autocast("cuda", enabled=amp):
                         val_data["pred"] = sliding_window_inference(
                             inputs=val_data["image"].to(_device_in),
                             roi_size=roi_size_valid,


### PR DESCRIPTION
Fix #411

To prevent deprecated errors in PyTorch 2.6 and later versions, make the following adjustments:

- Incorporate `weights_only=False` in segresnet, while setting `weights_only=True` for other algorithms.
- Transition to using` torch.GradScaler("cuda", args...)` and `torch.autocast("cuda", args...)`, as recommended by the latest documentation at [PyTorch AMP](https://pytorch.org/docs/stable/amp.html).