### PR TITLE
Update `weights_only=False` in dints algorithm

### DIFF
--- a/auto3dseg/algorithm_templates/dints/configs/network.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/network.yaml
@@ -1,7 +1,7 @@
 ---
 training_network:
   arch_ckpt_path: "$@bundle_root + '/scripts/arch_code.pth'"
-  arch_ckpt: "$torch.load(@training_network#arch_ckpt_path, map_location=torch.device('cuda'), weights_only=True)"
+  arch_ckpt: "$torch.load(@training_network#arch_ckpt_path, map_location=torch.device('cuda'), weights_only=False)"
   dints_space:
     _target_: TopologyInstance
     channel_mul: 1


### PR DESCRIPTION
Fix #411 

Update to use `weights_only=False` in dints since the checkpoint not only save weights
https://github.com/KumoLiu/research-contributions/blob/main/auto3dseg/algorithm_templates/dints/configs/network.yaml#L12
