### PR TITLE
Remove deprecated `img_size` args in `SwinUNETR`

### DIFF
--- a/DAE/BTCV_Finetune/utils/data_utils.py
+++ b/DAE/BTCV_Finetune/utils/data_utils.py
@@ -80,7 +80,7 @@ def get_loader(args):
             transforms.ScaleIntensityRanged(
                 keys=["image"], a_min=args.a_min, a_max=args.a_max, b_min=args.b_min, b_max=args.b_max, clip=True
             ),
-            transforms.CropForegroundd(keys=["image", "label"], source_key="image"),
+            transforms.CropForegroundd(keys=["image", "label"], source_key="image", allow_smaller=True),
             transforms.RandCropByPosNegLabeld(
                 keys=["image", "label"],
                 label_key="label",
@@ -111,7 +111,7 @@ def get_loader(args):
             transforms.ScaleIntensityRanged(
                 keys=["image"], a_min=args.a_min, a_max=args.a_max, b_min=args.b_min, b_max=args.b_max, clip=True
             ),
-            transforms.CropForegroundd(keys=["image", "label"], source_key="image"),
+            transforms.CropForegroundd(keys=["image", "label"], source_key="image", allow_smaller=True),
             transforms.ToTensord(keys=["image", "label"]),
         ]
     )

--- a/DAE/Pretrain_full_contrast/data/data_pretrain.py
+++ b/DAE/Pretrain_full_contrast/data/data_pretrain.py
@@ -21,7 +21,6 @@ from monai.transforms import (
     AsChannelFirstd,
     AsDiscrete,
     Compose,
-    CropForegroundd,
     LoadImaged,
     NormalizeIntensityd,
     Orientationd,

--- a/SwinMM/WORD/models/swin_unetr.py
+++ b/SwinMM/WORD/models/swin_unetr.py
@@ -38,7 +38,6 @@ class SwinUNETR(swin_unetr.SwinUNETR):
 
         """
         super().__init__(
-            img_size,
             *args,
             num_heads=num_heads,
             feature_size=feature_size,

--- a/SwinUNETR/BRATS21/README.md
+++ b/SwinUNETR/BRATS21/README.md
@@ -106,8 +106,7 @@ Mean Dice refers to average Dice of WT, ET and TC tumor semantic classes.
 A Swin UNETR network with standard hyper-parameters for brain tumor semantic segmentation (BraTS dataset) is be defined as:
 
 ``` bash
-model = SwinUNETR(img_size=(128,128,128),
-                  in_channels=4,
+model = SwinUNETR(in_channels=4,
                   out_channels=3,
                   feature_size=48,
                   use_checkpoint=True,

--- a/SwinUNETR/BRATS21/main.py
+++ b/SwinUNETR/BRATS21/main.py
@@ -127,7 +127,6 @@ def main_worker(gpu, args):
     pretrained_pth = os.path.join(pretrained_dir, model_name)
 
     model = SwinUNETR(
-        img_size=(args.roi_x, args.roi_y, args.roi_z),
         in_channels=args.in_channels,
         out_channels=args.out_channels,
         feature_size=args.feature_size,

--- a/SwinUNETR/BRATS21/test.py
+++ b/SwinUNETR/BRATS21/test.py
@@ -70,7 +70,6 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     pretrained_pth = os.path.join(pretrained_dir, model_name)
     model = SwinUNETR(
-        img_size=128,
         in_channels=args.in_channels,
         out_channels=args.out_channels,
         feature_size=args.feature_size,

--- a/SwinUNETR/BRATS21/utils/data_utils.py
+++ b/SwinUNETR/BRATS21/utils/data_utils.py
@@ -99,7 +99,7 @@ def get_loader(args):
             transforms.LoadImaged(keys=["image", "label"]),
             transforms.ConvertToMultiChannelBasedOnBratsClassesd(keys="label"),
             transforms.CropForegroundd(
-                keys=["image", "label"], source_key="image", k_divisible=[args.roi_x, args.roi_y, args.roi_z]
+                keys=["image", "label"], source_key="image", k_divisible=[args.roi_x, args.roi_y, args.roi_z], allow_smaller=True
             ),
             transforms.RandSpatialCropd(
                 keys=["image", "label"], roi_size=[args.roi_x, args.roi_y, args.roi_z], random_size=False

--- a/SwinUNETR/BTCV/README.md
+++ b/SwinUNETR/BTCV/README.md
@@ -84,8 +84,7 @@ Once the json file is downloaded, please place it in the same folder as the data
 A Swin UNETR network with standard hyper-parameters for multi-organ semantic segmentation (BTCV dataset) is be defined as:
 
 ``` bash
-model = SwinUNETR(img_size=(96,96,96),
-                  in_channels=1,
+model = SwinUNETR(in_channels=1,
                   out_channels=14,
                   feature_size=48,
                   use_checkpoint=True,

--- a/SwinUNETR/BTCV/main.py
+++ b/SwinUNETR/BTCV/main.py
@@ -127,7 +127,6 @@ def main_worker(gpu, args):
 
     pretrained_dir = args.pretrained_dir
     model = SwinUNETR(
-        img_size=(args.roi_x, args.roi_y, args.roi_z),
         in_channels=args.in_channels,
         out_channels=args.out_channels,
         feature_size=args.feature_size,

--- a/SwinUNETR/BTCV/test.py
+++ b/SwinUNETR/BTCV/test.py
@@ -71,7 +71,6 @@ def main():
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     pretrained_pth = os.path.join(pretrained_dir, model_name)
     model = SwinUNETR(
-        img_size=96,
         in_channels=args.in_channels,
         out_channels=args.out_channels,
         feature_size=args.feature_size,

--- a/SwinUNETR/BTCV/utils/data_utils.py
+++ b/SwinUNETR/BTCV/utils/data_utils.py
@@ -80,7 +80,7 @@ def get_loader(args):
             transforms.ScaleIntensityRanged(
                 keys=["image"], a_min=args.a_min, a_max=args.a_max, b_min=args.b_min, b_max=args.b_max, clip=True
             ),
-            transforms.CropForegroundd(keys=["image", "label"], source_key="image"),
+            transforms.CropForegroundd(keys=["image", "label"], source_key="image", allow_smaller=True),
             transforms.RandCropByPosNegLabeld(
                 keys=["image", "label"],
                 label_key="label",
@@ -111,7 +111,7 @@ def get_loader(args):
             transforms.ScaleIntensityRanged(
                 keys=["image"], a_min=args.a_min, a_max=args.a_max, b_min=args.b_min, b_max=args.b_max, clip=True
             ),
-            transforms.CropForegroundd(keys=["image", "label"], source_key="image"),
+            transforms.CropForegroundd(keys=["image", "label"], source_key="image", allow_smaller=True),
             transforms.ToTensord(keys=["image", "label"]),
         ]
     )

--- a/SwinUNETR/Pretrain/utils/data_utils.py
+++ b/SwinUNETR/Pretrain/utils/data_utils.py
@@ -78,7 +78,7 @@ def get_loader(args):
                 keys=["image"], a_min=args.a_min, a_max=args.a_max, b_min=args.b_min, b_max=args.b_max, clip=True
             ),
             SpatialPadd(keys="image", spatial_size=[args.roi_x, args.roi_y, args.roi_z]),
-            CropForegroundd(keys=["image"], source_key="image", k_divisible=[args.roi_x, args.roi_y, args.roi_z]),
+            CropForegroundd(keys=["image"], source_key="image", k_divisible=[args.roi_x, args.roi_y, args.roi_z], allow_smaller=True),
             RandSpatialCropSamplesd(
                 keys=["image"],
                 roi_size=[args.roi_x, args.roi_y, args.roi_z],
@@ -98,7 +98,7 @@ def get_loader(args):
                 keys=["image"], a_min=args.a_min, a_max=args.a_max, b_min=args.b_min, b_max=args.b_max, clip=True
             ),
             SpatialPadd(keys="image", spatial_size=[args.roi_x, args.roi_y, args.roi_z]),
-            CropForegroundd(keys=["image"], source_key="image", k_divisible=[args.roi_x, args.roi_y, args.roi_z]),
+            CropForegroundd(keys=["image"], source_key="image", k_divisible=[args.roi_x, args.roi_y, args.roi_z], allow_smaller=True),
             RandSpatialCropSamplesd(
                 keys=["image"],
                 roi_size=[args.roi_x, args.roi_y, args.roi_z],

--- a/UNETR/BTCV/utils/data_utils.py
+++ b/UNETR/BTCV/utils/data_utils.py
@@ -80,7 +80,7 @@ def get_loader(args):
             transforms.ScaleIntensityRanged(
                 keys=["image"], a_min=args.a_min, a_max=args.a_max, b_min=args.b_min, b_max=args.b_max, clip=True
             ),
-            transforms.CropForegroundd(keys=["image", "label"], source_key="image"),
+            transforms.CropForegroundd(keys=["image", "label"], source_key="image", allow_smaller=True),
             transforms.RandCropByPosNegLabeld(
                 keys=["image", "label"],
                 label_key="label",
@@ -111,7 +111,7 @@ def get_loader(args):
             transforms.ScaleIntensityRanged(
                 keys=["image"], a_min=args.a_min, a_max=args.a_max, b_min=args.b_min, b_max=args.b_max, clip=True
             ),
-            transforms.CropForegroundd(keys=["image", "label"], source_key="image"),
+            transforms.CropForegroundd(keys=["image", "label"], source_key="image", allow_smaller=True),
             transforms.ToTensord(keys=["image", "label"]),
         ]
     )

--- a/auto3dseg/algorithm_templates/dints/configs/network.yaml
+++ b/auto3dseg/algorithm_templates/dints/configs/network.yaml
@@ -1,7 +1,7 @@
 ---
 training_network:
   arch_ckpt_path: "$@bundle_root + '/scripts/arch_code.pth'"
-  arch_ckpt: "$torch.load(@training_network#arch_ckpt_path, map_location=torch.device('cuda'), weights_only=True)"
+  arch_ckpt: "$torch.load(@training_network#arch_ckpt_path, map_location=torch.device('cuda'), weights_only=False)"
   dints_space:
     _target_: TopologyInstance
     channel_mul: 1

--- a/auto3dseg/algorithm_templates/dints/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/algo.py
@@ -158,6 +158,7 @@ class DintsAlgo(BundleAlgo):
                         "source_key": "@image_key",
                         "start_coord_key": None,
                         "end_coord_key": None,
+                        "allow_smaller": True,
                     },
                 ],
             }
@@ -174,7 +175,7 @@ class DintsAlgo(BundleAlgo):
                         "b_max": 1.0,
                         "clip": True,
                     },
-                    {"_target_": "CropForegroundd", "keys": "@image_key", "source_key": "@image_key"},
+                    {"_target_": "CropForegroundd", "keys": "@image_key", "source_key": "@image_key", "allow_smaller": True},
                 ],
             }
 

--- a/auto3dseg/algorithm_templates/swinunetr/configs/network.yaml
+++ b/auto3dseg/algorithm_templates/swinunetr/configs/network.yaml
@@ -1,7 +1,6 @@
 network:
   _target_: SwinUNETR
   feature_size: 48
-  img_size: 96
   in_channels: "@input_channels"
   out_channels: "@output_classes"
   spatial_dims: 3

--- a/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
+++ b/auto3dseg/algorithm_templates/swinunetr/scripts/algo.py
@@ -168,6 +168,7 @@ class SwinunetrAlgo(BundleAlgo):
                         "source_key": "@image_key",
                         "start_coord_key": None,
                         "end_coord_key": None,
+                        "allow_smaller": True,
                     },
                 ],
             }
@@ -183,7 +184,7 @@ class SwinunetrAlgo(BundleAlgo):
                         "b_max": 1.0,
                         "clip": True,
                     },
-                    {"_target_": "CropForegroundd", "keys": "@image_key", "source_key": "@image_key"},
+                    {"_target_": "CropForegroundd", "keys": "@image_key", "source_key": "@image_key", "allow_smaller": True},
                 ],
             }
             mr_intensity_transform = {


### PR DESCRIPTION
Remove deprecated `img_size` args in `SwinUNETR`
Add `allow_smaller=True` in CropForeground / CropForegroundd since default value has been changed

https://github.com/Project-MONAI/MONAI/pull/8430