### PR TITLE
Replace apex clip_grad_norm_ with PyTorch native in dints templates

### DIFF
--- a/auto3dseg/algorithm_templates/dints/scripts/search.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/search.py
@@ -40,10 +40,7 @@ from monai.inferers import sliding_window_inference
 from monai.metrics import compute_dice
 from monai.utils import RankFilter, set_determinism
 
-try:
-    from apex.contrib.clip_grad import clip_grad_norm_
-except ModuleNotFoundError:
-    from torch.nn.utils import clip_grad_norm_
+from torch.nn.utils import clip_grad_norm_
 
 
 CONFIG = {

--- a/auto3dseg/algorithm_templates/dints/scripts/train.py
+++ b/auto3dseg/algorithm_templates/dints/scripts/train.py
@@ -47,10 +47,7 @@ from torch.nn.parallel import DistributedDataParallel
 from torch.utils.tensorboard import SummaryWriter
 from tqdm import tqdm
 
-try:
-    from apex.contrib.clip_grad import clip_grad_norm_
-except ModuleNotFoundError:
-    from torch.nn.utils import clip_grad_norm_
+from torch.nn.utils import clip_grad_norm_
 
 try:
     _libcudart = ctypes.CDLL("libcudart.so")


### PR DESCRIPTION
## Summary
- Remove `apex.contrib.clip_grad.clip_grad_norm_` from dints auto3dseg templates (`train.py` and `search.py`)
- Use `torch.nn.utils.clip_grad_norm_` instead, which handles all tensor types correctly including those with lazy/functional storage in PyTorch >=2.10
- The previous try/except only caught `ModuleNotFoundError` (apex not installed), but not the `RuntimeError` when apex is installed but its `multi_tensor_applier` is incompatible with newer PyTorch tensor storage

## Root cause
On PyTorch >=2.10 (e.g., NGC 25.12), some gradient tensors use lazy/functional storage that no longer exposes a traditional data pointer. `apex.contrib.clip_grad.clip_grad_norm_` calls `multi_tensor_applier` which tries to access the raw data pointer, causing:
```
RuntimeError: Cannot access data pointer of Tensor that doesn't have storage
```

## Test plan
- [x] No remaining references to `apex.contrib.clip_grad` in the repository
- [x] All call sites use `torch.nn.utils.clip_grad_norm_` (either via import alias or fully-qualified)
- [ ] Run auto3dseg dints training on NGC 25.12 container to verify no crash

Fixes Project-MONAI/MONAI#8737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified gradient clipping implementation to use PyTorch exclusively, removing optional dependency handling for external libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->