### PR TITLE
Fix #422: Added --fold argument and 5-fold cross-validation logic

### DIFF
--- a/UNETR/BTCV/main.py
+++ b/UNETR/BTCV/main.py
@@ -91,7 +91,7 @@ parser.add_argument("--resume_ckpt", action="store_true", help="resume training 
 parser.add_argument("--resume_jit", action="store_true", help="resume training from pretrained torchscript checkpoint")
 parser.add_argument("--smooth_dr", default=1e-6, type=float, help="constant added to dice denominator to avoid nan")
 parser.add_argument("--smooth_nr", default=0.0, type=float, help="constant added to dice numerator to avoid zero")
-
+parser.add_argument("--fold", default=0, type=int, help="fold number for 5-fold cross-validation (0-4)")
 
 def main():
     args = parser.parse_args()

--- a/UNETR/BTCV/utils/data_utils.py
+++ b/UNETR/BTCV/utils/data_utils.py
@@ -131,12 +131,20 @@ def get_loader(args):
         )
         loader = test_loader
     else:
-        datalist = load_decathlon_datalist(datalist_json, True, "training", base_dir=data_dir)
+        full_datalist = load_decathlon_datalist(datalist_json, True, "training", base_dir=data_dir)
+        folds = data.partition_dataset(data=full_datalist, num_partitions=5, shuffle=True, seed=42)
+        val_files = folds[args.fold]
+        
+        train_files = []
+        for i in range(5):
+            if i != args.fold:
+                train_files.extend(folds[i])
+        
         if args.use_normal_dataset:
-            train_ds = data.Dataset(data=datalist, transform=train_transform)
+            train_ds = data.Dataset(data=train_files, transform=train_transform)
         else:
             train_ds = data.CacheDataset(
-                data=datalist, transform=train_transform, cache_num=24, cache_rate=1.0, num_workers=args.workers
+                data=train_files, transform=train_transform, cache_num=24, cache_rate=1.0, num_workers=args.workers
             )
         train_sampler = Sampler(train_ds) if args.distributed else None
         train_loader = data.DataLoader(
@@ -148,7 +156,7 @@ def get_loader(args):
             pin_memory=True,
             persistent_workers=True,
         )
-        val_files = load_decathlon_datalist(datalist_json, True, "validation", base_dir=data_dir)
+        
         val_ds = data.Dataset(data=val_files, transform=val_transform)
         val_sampler = Sampler(val_ds, shuffle=False) if args.distributed else None
         val_loader = data.DataLoader(

--- a/UNETR/BTCV/utils/data_utils.py
+++ b/UNETR/BTCV/utils/data_utils.py
@@ -134,12 +134,12 @@ def get_loader(args):
         full_datalist = load_decathlon_datalist(datalist_json, True, "training", base_dir=data_dir)
         folds = data.partition_dataset(data=full_datalist, num_partitions=5, shuffle=True, seed=42)
         val_files = folds[args.fold]
-        
+
         train_files = []
         for i in range(5):
             if i != args.fold:
                 train_files.extend(folds[i])
-        
+
         if args.use_normal_dataset:
             train_ds = data.Dataset(data=train_files, transform=train_transform)
         else:
@@ -156,7 +156,7 @@ def get_loader(args):
             pin_memory=True,
             persistent_workers=True,
         )
-        
+
         val_ds = data.Dataset(data=val_files, transform=val_transform)
         val_sampler = Sampler(val_ds, shuffle=False) if args.distributed else None
         val_loader = data.DataLoader(


### PR DESCRIPTION
### Description
This PR resolves issue #422. The repository mentioned using 5-fold cross-validation for the UNET/UNETR model on the BTCV dataset, but the `--fold` argument was missing in `main.py` and the cross-validation data splitting logic was unimplemented.

### Changes Made
- Added the `--fold` argument to the argument parser in `main.py`.
- Implemented 5-fold cross-validation splitting using MONAI's `partition_dataset` in `utils/data_utils.py` based on the requested fold index.

Fixes #422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting one of five cross-validation folds through a command-line option.
  * Training and validation data are now automatically partitioned by the selected fold.

* **Bug Fixes**
  * Improved dataset preparation to ensure the selected fold is used for validation while the remaining folds are used for training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->